### PR TITLE
Use square instead of multiplication in fast-expt

### DIFF
--- a/exercises/01/fast-expt.scm
+++ b/exercises/01/fast-expt.scm
@@ -3,8 +3,7 @@
 (define (fast-expt base exp)
   (cond ((= exp 0) 1)
         ((even? exp)
-          (* (fast-expt base (/ exp 2))
-             (fast-expt base (/ exp 2))))
+          (sqr (fast-expt base (/ exp 2))))
         ((odd? exp)
           (* base
              (fast-expt base (- exp 1))))))


### PR DESCRIPTION
Replace multiplication with square so that the expression is evaluated
only once